### PR TITLE
Fixes failing test: afterEach() should exit domain

### DIFF
--- a/test/thrushTest.js
+++ b/test/thrushTest.js
@@ -486,6 +486,11 @@ describe('Promise', function(){
             };
 
         });
+        afterEach(function(){
+            if (process.domain) {
+                process.domain.exit();
+            }
+        });
         it('should promisify a callback function', function(){
             var safe = Promise.safelyPromisify(callbackish);
             var safeBound = Promise.safelyPromisify(callbackish, {result: 123});


### PR DESCRIPTION
I noticed a test failure due to process.domain being true at the beginning of one of the tests. I added an afterEach in the domain-related tests, exiting any process.domain.